### PR TITLE
temporary solution for test filter

### DIFF
--- a/rules/scala/test/Test.scala
+++ b/rules/scala/test/Test.scala
@@ -1,6 +1,6 @@
 package annex
 
-import sbt.testing.{AnnotatedFingerprint, Fingerprint, Framework, Logger, Status, SubclassFingerprint, SuiteSelector, Task, TaskDef}
+import sbt.testing.{AnnotatedFingerprint, Fingerprint, Framework, Logger, Status, SubclassFingerprint, SuiteSelector, TestWildcardSelector, Task, TaskDef}
 import scala.collection.{breakOut, mutable}
 import scala.util.control.NonFatal
 import xsbt.api.Discovery
@@ -46,14 +46,14 @@ class TestFramework(loader: ClassLoader, framework: Framework, logger: Logger) {
     new TestDiscovery(subclassPrints, annotatedPrints)
   }
 
-  def execute(tests: Seq[TestDefinition]): Boolean = {
+  def execute(tests: Seq[TestDefinition], scopeAndTestName: String): Boolean = {
     val thread = Thread.currentThread
     val classLoader = thread.getContextClassLoader
     thread.setContextClassLoader(loader)
     try {
-      val runner = framework.runner(Array.empty, Array.empty, loader)
+      val runner = framework.runner(Array.empty, if (framework.name == "specs2") Array("-ex", scopeAndTestName.replaceAll(".*::", "")) else Array.empty, loader)
       try {
-        val taskDefs = tests.map(test => new TaskDef(test.name, test.fingerprint, false, Array(new SuiteSelector)))
+        val taskDefs = tests.map(test => new TaskDef(test.name, test.fingerprint, false, Array(new TestWildcardSelector(scopeAndTestName.replace("::", " ")))))
         val tasks = runner.tasks(taskDefs.toArray)
         logger.info(s"${framework.getClass.getName}: ${tests.size} tests")
         logger.info("")

--- a/rules/scala/test/TestRunner.scala
+++ b/rules/scala/test/TestRunner.scala
@@ -112,9 +112,12 @@ object TestRunner {
     val loader = new TestFrameworkLoader(classLoader, logger)
     val frameworks = testNamespace.getList[String]("frameworks").asScala.flatMap(loader.load)
 
-    val testPattern = sys.env
+    val testClass = sys.env
       .get("TESTBRIDGE_TEST_ONLY")
-      .map(text => Pattern.compile(raw"\Q${text.replace("*", raw"\E.*\Q")}\E"))
+      .map(text => Pattern.compile(if (text contains "#") raw"${text.replaceAll("#.*", "")}" else text))
+    val testScopeAndName = sys.env
+      .get("TESTBRIDGE_TEST_ONLY")
+      .map(text => if (text contains "#") text.replaceAll(".*#", "").replaceAll("\\$", "").replace("\\Q", "").replace("\\E", "") else "")
 
     var count = 0
     val passed = frameworks.forall { framework =>
@@ -124,12 +127,12 @@ object TestRunner {
         total <- sys.env.get("TEST_TOTAL_SHARDS").map(_.toInt)
       } yield (test: TestDefinition, i: Int) => i % total == index
       val filteredTests = tests.filter { test =>
-        testPattern.forall(_.matcher(test.name).matches) && {
+        testClass.forall(_.matcher(test.name).matches) && {
           count += 1
           filter.fold(true)(_(test, count))
         }
       }
-      filteredTests.isEmpty || framework.execute(filteredTests)
+      filteredTests.isEmpty || framework.execute(filteredTests, testScopeAndName.get)
     }
     sys.exit(if (passed) 0 else 1)
   }


### PR DESCRIPTION
### This is a temporary solution for ScalaTest and Specs2 to run individual test
## For ScalaTest
- Fix the regex error when clicking the button for individual test.
- This solution works with the latest commit `temporary solution for test filter` from `lucidsoftware/intellij`, **PULL THE COMMIT**.
## For Specs2
- Support running smaller tests
- **ISSUE**: this solution only matches the `testname` rather than `scopename::testname`, which means tests in different scopes with same testname will be run at the same time. We suggest to make testname unique across scopes. Possible solution is still under investigation.